### PR TITLE
Enforce LF line endings in .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+# convert all bash scripts to run with linux line endings by default.
+*.sh text eol=lf


### PR DESCRIPTION
**What does this do?**

This PR adds a .gitattributes file that ensures that .sh files will be parsed with unix-style LF line endings as opposed to Windows-style CRLF endings.

**Why is it here?**

On windows, git's default configuration converts line endings to CRLF by default ( core.autocrlf ). It's usually not an issue, but if a user running Windows tries to run a bash script from a cloned repo without core.autocrlf set to false, they will be hit with errors when the scripts are run.

By adding this .gitattributes file, the bash scripts in this repository will run properly regardless of whether a user on Windows has properly set their git configuration. It is a subtle convenience addition that only affects how bash scripts run on Windows. Users on OSX or Linux should experience no difference.