### PR TITLE
Add tests independent of db structure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2'
 services:
 
+  ### DB START
   # This is the database to which the all the other components in the stack will connect and interact with
   # (but mostly it's PostgREST that is going to be responsible for the bulk of the db traffic)
   # Having the database in a container is very convinient in development but in production you will
@@ -27,6 +28,7 @@ services:
 
     volumes:
       - "./db/src:/docker-entrypoint-initdb.d"
+  ### DB END
 
   # PostgREST instance, is responsible for communicating with the database
   # and providing a REST api, (almost) every request that is sent to the database goes through it

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "test_rest": "mocha --compilers js:babel-core/register ./tests/rest/",
-    "test_db": "( set -a && . ./.env && set +a && docker run -i -t --rm --name pgtap --net ${COMPOSE_PROJECT_NAME}_default --link ${COMPOSE_PROJECT_NAME}_db_1:db -v $(pwd)/tests/db/:/test -e DATABASE=$DB_NAME -e USER=$SUPER_USER -e PASSWORD=$SUPER_USER_PASSWORD lren/pgtap )",
+    "test_db": "( set -a && . ./.env && set +a && docker run -i -t --rm --name pgtap --net ${COMPOSE_PROJECT_NAME}_default --link ${COMPOSE_PROJECT_NAME}_db_1:db -v $(pwd)/tests/db/:/test -e HOST=$DB_HOST -e DATABASE=$DB_NAME -e USER=$SUPER_USER -e PASSWORD=$SUPER_USER_PASSWORD lren/pgtap )",
     "test": "npm run test_db && npm run test_rest"
   },
   "author": "ruslan.talpa@subzero.cloud",

--- a/tests/db/README.md
+++ b/tests/db/README.md
@@ -10,6 +10,7 @@ To run the tests in this directory do the following
 	--network ${COMPOSE_PROJECT_NAME}_default \
 	--link ${COMPOSE_PROJECT_NAME}_db_1:db \
 	-v $(pwd)/tests/db/:/test \
+  -e HOST=$DB_HOST \
 	-e DATABASE=$DB_NAME \
 	-e USER=$SUPER_USER \
 	-e PASSWORD=$SUPER_USER_PASSWORD \

--- a/tests/db/README.md
+++ b/tests/db/README.md
@@ -9,7 +9,7 @@ To run the tests in this directory do the following
 	docker run -i -t --rm --name pgtap \
 	--network ${COMPOSE_PROJECT_NAME}_default \
 	--link ${COMPOSE_PROJECT_NAME}_db_1:db \
-	-v $(pwd)/db/tests/:/test \
+	-v $(pwd)/tests/db/:/test \
 	-e DATABASE=$DB_NAME \
 	-e USER=$SUPER_USER \
 	-e PASSWORD=$SUPER_USER_PASSWORD \

--- a/tests/db/simple.sql
+++ b/tests/db/simple.sql
@@ -1,0 +1,11 @@
+begin;
+select * from no_plan();
+
+select has_schema('information_schema');
+
+select has_view('information_schema', 'routines', 'has routines information_schema.routines view');
+
+select has_column('information_schema', 'routines', 'specific_name', 'has information_schema.routines.specific_name column');
+
+select * from finish();
+rollback;

--- a/tests/rest/simple.js
+++ b/tests/rest/simple.js
@@ -1,0 +1,11 @@
+const request = require('supertest');
+const should = require("should");
+
+describe('root endpoint', function() {
+  it('returns json', function(done) {
+    request('http://localhost:8080/rest')
+      .get('/')
+      .expect('Content-Type', /json/)
+      .expect(200, done)
+  });
+});


### PR DESCRIPTION
`$DB_HOST` was needed so `npm run test_db` can work when having an `external` db.