### PR TITLE
Verbosely log errors resetting database

### DIFF
--- a/tests/rest/common.js
+++ b/tests/rest/common.js
@@ -1,10 +1,14 @@
-import {config} from 'dotenv';
-import {spawnSync} from 'child_process';
+import {
+  config
+} from 'dotenv';
+import {
+  spawnSync
+} from 'child_process';
 // var execSync = require('child_process').execSync;
 const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJyb2xlIjoid2VidXNlciJ9.uSsS2cukBlM6QXe4Y0H90fsdkJSGcle9b7p_kMV1Ymk'
 const request = require('supertest');
 
-config();//.env file vars added to process.env
+config(); //.env file vars added to process.env
 const COMPOSE_PROJECT_NAME = process.env.COMPOSE_PROJECT_NAME;
 const POSTGRES_USER = process.env.POSTGRES_USER;
 const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD;
@@ -19,18 +23,24 @@ const psql_version = spawnSync('psql', ['--version']);
 const have_psql = (psql_version.stdout && psql_version.stdout.toString('utf8').trim().length > 0)
 
 
-var rest_service = function() { 
+var rest_service = function () {
   return request('http://localhost:8080/rest');
 }
 
 const resetdb = () => {
-  if (have_psql){
-    var env = Object.create( process.env );
+  let pgResult;
+  if (have_psql) {
+    var env = Object.create(process.env);
     env.PGPASSWORD = SUPER_USER_PASSWORD
-    const pg = spawnSync('psql', ['-h', 'localhost', '-U', SUPER_USER, DB_NAME, '-f', process.env.PWD + '/db/src/sample_data/reset.sql'], { env: env })
+    pgResult = spawnSync('psql', ['-h', 'localhost', '-U', SUPER_USER, DB_NAME, '-f', process.env.PWD + '/db/src/sample_data/reset.sql'], {
+      env: env
+    })
+  } else {
+    pgResult = spawnSync('docker', ['exec', PG, 'psql', '-U', SUPER_USER, DB_NAME, '-f', 'docker-entrypoint-initdb.d/sample_data/reset.sql'])
   }
-  else{
-    const pg = spawnSync('docker', ['exec', PG, 'psql', '-U', SUPER_USER, DB_NAME, '-f', 'docker-entrypoint-initdb.d/sample_data/reset.sql'])
+  if (pgResult.status !== 0) {
+    const errMsg = pgResult.stderr.toString();
+    throw new Error(`Could not reset database in rest tests. Stderr was: ${errMsg}`);
   }
 }
 


### PR DESCRIPTION
This helps users know when there exists errors in their `reset.sql` or related database reset script that would otherwise pass silently.